### PR TITLE
[POC] Validate for extra arguments

### DIFF
--- a/spec/ArgumentResolver/InstantiatorSpec.php
+++ b/spec/ArgumentResolver/InstantiatorSpec.php
@@ -12,7 +12,7 @@ class InstantiatorSpec extends ObjectBehavior
     function it_instantiate_a_class_with_resolved_arguments(ArgumentResolver $argumentResolver)
     {
         $this->beConstructedWith($argumentResolver);
-        $argumentResolver->resolveArguments(Argument::any(), Argument::any())->willReturn([1, 'foo', 3]);
-        $this->instantiate(Resolution::class, [])->shouldBeLike(new Resolution(1, 'foo', 3));
+        $argumentResolver->resolveArguments(Argument::any(), Argument::any())->willReturn([1, 'foo', 'foo', 3]);
+        $this->instantiate(Resolution::class, [])->shouldBeLike(new Resolution(1, 'foo', 'foo', 3));
     }
 }

--- a/spec/ArgumentResolver/Resolution/ResolutionSpec.php
+++ b/spec/ArgumentResolver/Resolution/ResolutionSpec.php
@@ -8,7 +8,7 @@ class ResolutionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith(0, 'value', 1);
+        $this->beConstructedWith(0, 'name', 'value', 1);
     }
 
     function it_exposes_value()

--- a/spec/ArgumentResolver/Resolution/ResolutionsSpec.php
+++ b/spec/ArgumentResolver/Resolution/ResolutionsSpec.php
@@ -14,13 +14,13 @@ class ResolutionsSpec extends ObjectBehavior
 
     function it_supports_adding_resolution()
     {
-        $this->add(new Resolution(1, 2, 3));
+        $this->add(new Resolution(1, 2, 3, 4));
     }
 
     function it_supports_addind_collection_of_resolutions()
     {
         $this->addCollection([
-            new Resolution(1, 2, 3),
+            new Resolution(1, 2, 3, 4),
         ]);
     }
 
@@ -31,20 +31,20 @@ class ResolutionsSpec extends ObjectBehavior
 
     function it_sorts_the_resolutions_by_priority()
     {
-        $this->add(new Resolution(1, 2, 1));
-        $this->add(new Resolution(1, 2, 2));
+        $this->add(new Resolution(1, 'one', 2, 1));
+        $this->add(new Resolution(1, 'two', 2, 2));
 
         $this->sortByPriority()->toArray()->shouldBeLike([
-            new Resolution(1, 2, 2),
-            new Resolution(1, 2, 1),
+            new Resolution(1, 'two', 2, 2),
+            new Resolution(1, 'one', 2, 1),
         ]);
     }
 
     function it_returns_the_argument_values_as_array()
     {
-        $this->add(new Resolution(0, 'foo', 1));
-        $this->add(new Resolution(2, 'bar', 2));
-        $this->add(new Resolution(1, 2, 2));
+        $this->add(new Resolution(0, 'one', 'foo', 1));
+        $this->add(new Resolution(2, 'two', 'bar', 2));
+        $this->add(new Resolution(1, 'three', 2, 2));
 
         $this->toArgumentsArray()->shouldReturn([
             'foo',
@@ -55,25 +55,25 @@ class ResolutionsSpec extends ObjectBehavior
 
     function it_returns_the_missing_resolution_keys()
     {
-        $this->add(new Resolution(0, 'foo', 1));
-        $this->add(new Resolution(2, 'bar', 2));
-        $this->add(new Resolution(4, 'bar', 2));
+        $this->add(new Resolution(0, 'one', 'foo', 1));
+        $this->add(new Resolution(2, 'two', 'bar', 2));
+        $this->add(new Resolution(4, 'three', 'bar', 2));
 
         $this->getMissingResolutionPositions()->shouldReturn([1, 3]);
     }
 
     function it_returns_the_missing_resolution_keys_including_the_missing_parameter()
     {
-        $this->add(new Resolution(0, 'foo', 1));
-        $this->add(new Resolution(2, 'bar', 2));
+        $this->add(new Resolution(0, 'one', 'foo', 1));
+        $this->add(new Resolution(2, 'two', 'bar', 2));
 
         $this->getMissingResolutionPositions(4)->shouldReturn([1, 3]);
     }
 
     function it_returns_the_missing_resolution_keys_including_the_missing_parameters()
     {
-        $this->add(new Resolution(0, 'foo', 1));
-        $this->add(new Resolution(2, 'bar', 2));
+        $this->add(new Resolution(0, 'one', 'foo', 1));
+        $this->add(new Resolution(2, 'two', 'bar', 2));
 
         $this->getMissingResolutionPositions(5)->shouldReturn([1, 3, 4]);
     }

--- a/src/ArgumentResolver/ArgumentResolver.php
+++ b/src/ArgumentResolver/ArgumentResolver.php
@@ -62,6 +62,8 @@ class ArgumentResolver
 
         $arguments = $resolutions->sortByPriority()->toArgumentsArray();
 
+        $this->validateAgainstExtraArguments($availableArguments, $resolutions);
+
         return $arguments;
     }
 
@@ -80,7 +82,7 @@ class ArgumentResolver
             $priority = $this->getArgumentPriority($constraints, $description, $argumentName, $argumentValue);
 
             if ($priority > 0) {
-                $resolutions[] = new Resolution($description->getPosition(), $argumentValue, $priority);
+                $resolutions[] = new Resolution($description->getPosition(), $argumentName, $argumentValue, $priority);
             }
         }
 
@@ -142,7 +144,18 @@ class ArgumentResolver
                 );
             }
 
-            $resolutions->add(new Resolution($description->getPosition(), $description->getDefaultValue(), 0));
+            $resolutions->add(new Resolution($description->getPosition(), $description->getName(), $description->getDefaultValue(), 0));
+        }
+    }
+
+    private function validateAgainstExtraArguments(array $availableArguments, Resolutions $resolutions)
+    {
+        $unrecognisedArguments = array_diff(array_keys($availableArguments), $resolutions->argumentNames());
+        if (count($unrecognisedArguments) > 1) {
+            throw new RuntimeException(sprintf(
+                'The following arguments are not known: "%s", known arguments: "%s"',
+                implode('", "', $unrecognisedArguments), implode('", "', $resolutions->argumentNames())
+            ));
         }
     }
 }

--- a/src/ArgumentResolver/Resolution/Resolution.php
+++ b/src/ArgumentResolver/Resolution/Resolution.php
@@ -20,13 +20,19 @@ class Resolution
     private $priority;
 
     /**
+     * @var string
+     */
+    private $argumentName;
+
+    /**
      * @param int   $position
      * @param mixed $value
      * @param int   $priority
      */
-    public function __construct($position, $value, $priority)
+    public function __construct($position, $argumentName, $value, $priority)
     {
         $this->position = $position;
+        $this->argumentName = $argumentName;
         $this->value = $value;
         $this->priority = $priority;
     }
@@ -53,5 +59,13 @@ class Resolution
     public function priority()
     {
         return $this->priority;
+    }
+
+    /**
+     * @return string
+     */
+    public function argumentName()
+    {
+        return $this->argumentName;
     }
 }

--- a/src/ArgumentResolver/Resolution/Resolutions.php
+++ b/src/ArgumentResolver/Resolution/Resolutions.php
@@ -26,6 +26,16 @@ class Resolutions implements \IteratorAggregate
     }
 
     /**
+     * @return string[]
+     */
+    public function argumentNames()
+    {
+        return array_map(function (Resolution $resolution) {
+            return $resolution->argumentName();
+        }, $this->resolutions);
+    }
+
+    /**
      * @param array $resolutions
      */
     public function addCollection(array $resolutions)


### PR DESCRIPTION
This PR will make this library throw an exception if redundant arguments are given to the resolver.

e.g.

```
public function foobar($a, $b) {}
```

```
$resolver->resolveArguments('a' => 1, 'b' => 2, 'c' => 3);
```

:boom: `The following arguments are not known: "c", known arguments: "a", "b"'`

This is really very good for ensuring that both programmer typos and user typos do not silently miss their targets.

This is just a POC as I don't know if you want this in the library or not (and I have https://gitlab.com/dantleech/argument-resolver standing by otherwise).